### PR TITLE
Add supercapacitor charge % to tsmicroctl, use in tssupercapmon

### DIFF
--- a/scripts/tssupercapmon
+++ b/scripts/tssupercapmon
@@ -3,35 +3,63 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2019, Technologic Systems Inc.
 
+# Due to observed issues in some power installations, the script below has the
+# following behavior:
+#   - Once every half second, read the POWER_FAIL bit
+#   - If POWER_FAIL, monitor pct through tsmicroctl once per half second.
+#   - If pct is less than the threshold -AND- POWER_FAIL has been asserted for
+#       at least two checks in a row, then reboot the system.
+# The above AND is necessary to not reboot on spurious power fail events
+
+# Conservative value to wait for until shutting down
+RESET_PCT=90
+
 echo 73 > /sys/class/gpio/export 2>/dev/null
-power_failed=0
+
 while true; do
     power=$(cat /sys/class/gpio/gpio73/value)
-    if [ $power -ne 0 ] ; then
-        if [ $power_failed -eq 0 ]; then
-            # Code can be added below in order to turn off power-hungry
-            # devices, or start other shutdown procedures required.
-            # For example:
-            # Turn off cell modem on DC:
-            #   echo 233 > /sys/class/gpio/export 2>/dev/null
-            #   echo low > /sys/class/gpio/gpio233/direction
-            #
-            # Disable relays
-            #   echo 210 > /sys/class/gpio/export 2>/dev/null
-            #   echo 211 > /sys/class/gpio/export 2>/dev/null
-            #   echo low > /sys/class/gpio/gpio210/direction
-            #   echo low > /sys/class/gpio/gpio211/direction
-            #
-            # The wall command can be removed if wanted.
+    if [ "${power}" -ne 0 ]; then
 
-            wall The script /usr/local/bin/tssupercapmon has detected main power has been lost!  Shutting down safely to prevent filesystem damage
-            power_failed=1
-            shutdown -r now
+        # Not all tsmicroctl builds support reporting the supercap charge level.
+        # In the case of this string not being set, then just assume the current
+        # level is 0 and spit information out to the logs.
+        eval "$(/usr/local/bin/tsmicroctl -i)"
+        if [ ! -z "${supercap_pct}" ]; then
+            echo "Supercapacitors at ${supercap_pct}"
+        else
+            echo "\'tsmicroctl\' does not support reading charge percentage!"
+            echo "Please update \'tsmicroctl\'!"
+            supercap_pct=0
         fi
+
+        if [ "${supercap_pct}" -le $RESET_PCT ]; then
+            if [ "${power_failed}" -gt 0 ]; then
+                # Code can be added below in order to turn off power-hungry
+                # devices, or start other shutdown procedures required.
+                # For example:
+                # Turn off cell modem on DC:
+                #   echo 233 > /sys/class/gpio/export 2>/dev/null
+                #   echo low > /sys/class/gpio/gpio233/direction
+                #
+                # Disable relays
+                #   echo 210 > /sys/class/gpio/export 2>/dev/null
+                #   echo 211 > /sys/class/gpio/export 2>/dev/null
+                #   echo low > /sys/class/gpio/gpio210/direction
+                #   echo low > /sys/class/gpio/gpio211/direction
+                #
+                # The wall command can be removed if wanted.
+
+                wall The script /usr/local/bin/tssupercapmon has detected main power has been lost!  Shutting down safely to prevent filesystem damage
+
+                shutdown -r now
+                exit
+            fi
+        fi
+        let power_failed=power_failed+1
     else
-      power_failed=0
+        power_failed=0
     fi
 
-    sleep 1
+    sleep .5
 done
  

--- a/src/tsmicroctl.c
+++ b/src/tsmicroctl.c
@@ -59,6 +59,7 @@ int silabs_init()
 void do_info(int twifd)
 {
 	uint8_t data[28];
+	unsigned int pct;
 	bzero(data, 28);
 	read(twifd, data, 28);
 
@@ -75,6 +76,20 @@ void do_info(int twifd)
 	printf("P2_5=0x%x\n", data[20]<<8|data[21]);
 	printf("P2_6=0x%x\n", data[22]<<8|data[23]);
 	printf("P2_7=0x%x\n", data[24]<<8|data[25]);
+
+	/* The math below is the same that is used by U-Boot. The value of 2500
+	 * is the lowest viable charge level. Once above that, dividing down by
+	 * 23 gets roughly the full percentage scale. This max's out at ~102,
+	 * anything above that is considered to just be 100%
+	 */
+	pct = ((data[2]<<8 | data[3])*1000/409*2);
+	if (pct >= 2500) {
+		pct = ((pct - 2500)/23);
+		if (pct > 100) pct = 100;
+	} else {
+		pct = 0;
+	}
+	printf("supercap_pct=%d\n", pct);
 
 	printf("temp_sensor=0x%x\n", data[26]<<8|data[27]);
 	printf("reboot_source=");


### PR DESCRIPTION
Adds "supercap_pct=..." output to `tsmicroctl -i`

Updates `tssupercapmon` script to use this in its loop. Closely matches TS-7553-V2 and other implementations. However, due to variance that can occur with some power supplies, this script
also requires at least 2 checks (done 0.5 s apart) of POWER_FAIL being asserted AND the
charge percentage is lower than the set threshold.